### PR TITLE
[#10] Fix: "authKey TTL"

### DIFF
--- a/src/main/java/com/willyoubackend/domain/user/service/UserService.java
+++ b/src/main/java/com/willyoubackend/domain/user/service/UserService.java
@@ -123,7 +123,7 @@ public class UserService {
         } catch (MessagingException e) {
             e.printStackTrace();
         }
-        redisUtil.setDataExpire(email, authKey, 3 * 60 * 1L);
+        redisUtil.setDataExpire(email, authKey, 5 * 60 * 1L);
     }
 
     public ApiResponse<String> verifyEmail(VerifiRequest request) {


### PR DESCRIPTION
인증번호 삭제 기간 5분으로 수정

Resolves: None
Ref: None
Related to: #10